### PR TITLE
fix token callback WSGI app for Python 3

### DIFF
--- a/openidc_client/__init__.py
+++ b/openidc_client/__init__.py
@@ -456,10 +456,8 @@ class OpenIDCClient(object):
                 self._retrieved_code = kv['code']
 
             # Just return a message
-            out = StringIO()
-            out.write('You can close this window and return to the CLI')
             start_response('200 OK', [('Content-Type', 'text/plain')])
-            return [out.getvalue()]
+            return [u'You can close this window and return to the CLI'.encode('ascii')]
 
         self._retrieved_code = None
         server = self._get_server(_token_app)


### PR DESCRIPTION
On Python 3, the WSGI response iterable must yield bytes, not str.
Currently it produces spew like this in the calling application:

    Exception happened during processing of request from ('127.0.0.1', 59722)
    Traceback (most recent call last):
      File "/usr/lib64/python3.6/wsgiref/handlers.py", line 138, in run
	self.finish_response()
      File "/usr/lib64/python3.6/wsgiref/handlers.py", line 180, in finish_response
	self.write(data)
      File "/usr/lib64/python3.6/wsgiref/handlers.py", line 266, in write
	"write() argument must be a bytes instance"
    AssertionError: write() argument must be a bytes instance

Encode the response message as ASCII so that it becomes bytes not str
(also str not unicode on Python 2).

Also removed superfluous use of StringIO.