### PR TITLE
feat: really support not receiving refresh token

### DIFF
--- a/openidc_client/__init__.py
+++ b/openidc_client/__init__.py
@@ -405,7 +405,7 @@ class OpenIDCClient(object):
         :returns: True if the token was succesfully refreshed, False otherwise
         """
         oldtoken = self._cache[uuid]
-        if not oldtoken['refresh_token']:
+        if not oldtoken.get('refresh_token'):
             self.debug("Unable to refresh: no refresh token present")
             return False
         self.debug('Refreshing token %s', uuid)


### PR DESCRIPTION
The previous attempt would still crash if the key was not in the
dict at all (as seems to be the case with recent mediawiki), so
we need to handle that too.

Signed-off-by: Adam Williamson <awilliam@redhat.com>