### PR TITLE
Use default XDG state dir for cachedir

### DIFF
--- a/openidc_client/__init__.py
+++ b/openidc_client/__init__.py
@@ -107,7 +107,7 @@ class OpenIDCClient(object):
         self.client_secret = client_secret
         self.useragent = useragent or 'python-openid-client/%s' % \
             release.VERSION
-        self.cachedir = os.path.expanduser(cachedir or '~/.openidc')
+        self.cachedir = os.path.expanduser(cachedir or '~/.local/state/openidc')
         self.last_returned_uuid = None
         self.problem_reported = False
         self.token_to_try = None


### PR DESCRIPTION
Use ~/.local/state/openidc for as default cachedir.

I did not pull in https://github.com/srstevenson/xdg-base-dirs or any other
environment variable detections since I'm unsure about the supported
Python version. This is good enough for standard Fedora setups.
